### PR TITLE
fix: Use numeric run parameter for App-LabRecorder compatibility

### DIFF
--- a/lsl_recorder.py
+++ b/lsl_recorder.py
@@ -4,15 +4,23 @@ import time
 
 
 class LSLRecorder(object):
-
     def __init__(self, address="localhost", port=22345):
         self.socket = socket.create_connection((address, port))
 
     def set_recorder(self, root, subject, session, run, task):
         self.update()
         time.sleep(2)
-        msg = f"filename {{root:{root}}} {{participant:{subject}}} {{session:{session}}} {{run:{run}}} {{task:{task}}}\n"
-        self.socket.sendall(msg.encode("UTF-8"))
+        msg = (
+            b"filename {root:%b} {task:%b} {run:%x} {participant:%b} {session:%b}\n"
+            % (
+                root.encode("utf8"),
+                task.encode("utf8"),
+                run,
+                subject.encode("utf8"),
+                session.encode("utf8"),
+            )
+        )
+        self.socket.sendall(msg)
         time.sleep(1)
         return 0
 
@@ -37,7 +45,7 @@ if __name__ == "__main__":
         root=os.path.join(os.path.expanduser("~"), "Downloads", "test"),
         subject="03",
         session="05",
-        run="03",
+        run=3,
         task="test",
     )
     recorder.update()


### PR DESCRIPTION
- Switch from f-string to printf-style bytes formatting 
Turns out App-LabRecorder uses value.toInt() to parse the run parameter, 
so we need to send it the actual number instead of a string.